### PR TITLE
[Bugfix/4][Mostrar todos os vídeos de um curso] Utilizando o método get para melhorar a confiabilidade

### DIFF
--- a/submits/corretor/utils.py
+++ b/submits/corretor/utils.py
@@ -23,22 +23,21 @@ def list_videos(playlist_id):
     videos_data = []
     for video_data in response["items"]:
         try:
-            if "standard" in video_data['snippet']['thumbnails']:
-                videos_data.append(get_video_data_snippet(video_data, "standard"))
-            elif "default" in video_data['snippet']['thumbnails']:
-                videos_data.append(get_video_data_snippet(video_data, "default"))
+            if "standard" in video_data.get('snippet', '').get('thumbnails', ''):
+                key = "standard"
+            else:
+                key = "default"
+
+            videos_data.append({
+                'title': video_data.get('snippet', '').get('title', ''),
+                'image': video_data.get('snippet', '').get('thumbnails', '').get(key, '').get("url", ''),
+                'url': 'https://www.youtube.com/watch?v=' +
+                       video_data.get('snippet', '').get('thumbnails', '').get(key, '').get("url", '').split("/")[-2]
+            })
         except:
             pass
     return videos_data
 
-
-def get_video_data_snippet(video_data: dict, key: str):
-    return {
-        'title': video_data.get('snippet').get('title'),
-        'image': video_data.get('snippet').get('thumbnails').get(key, '').get("url", ''),
-        'url': 'https://www.youtube.com/watch?v=' +
-               video_data.get('snippet').get('thumbnails').get(key, '').get("url", '').split("/")[-2]
-    }
 
 
 def clean_submit_scripts():

--- a/submits/corretor/utils.py
+++ b/submits/corretor/utils.py
@@ -34,10 +34,10 @@ def list_videos(playlist_id):
 
 def get_video_data_snippet(video_data: dict, key: str):
     return {
-        'title': video_data['snippet']['title'],
-        'image': video_data['snippet']['thumbnails'][key]["url"],
+        'title': video_data.get('snippet').get('title'),
+        'image': video_data.get('snippet').get('thumbnails').get(key, '').get("url", ''),
         'url': 'https://www.youtube.com/watch?v=' +
-               video_data['snippet']['thumbnails'][key]["url"].split("/")[-2]
+               video_data.get('snippet').get('thumbnails').get(key, '').get("url", '').split("/")[-2]
     }
 
 

--- a/submits/corretor/utils.py
+++ b/submits/corretor/utils.py
@@ -23,16 +23,16 @@ def list_videos(playlist_id):
     videos_data = []
     for video_data in response["items"]:
         try:
-            if "standard" in video_data.get('snippet', '').get('thumbnails', ''):
+            if "standard" in video_data['snippet']['thumbnails']:
                 key = "standard"
             else:
                 key = "default"
 
             videos_data.append({
-                'title': video_data.get('snippet', '').get('title', ''),
-                'image': video_data.get('snippet', '').get('thumbnails', '').get(key, '').get("url", ''),
+                'title': video_data['snippet']['title'],
+                'image': video_data['snippet']['thumbnails'].get(key, '').get("url", ''),
                 'url': 'https://www.youtube.com/watch?v=' +
-                       video_data.get('snippet', '').get('thumbnails', '').get(key, '').get("url", '').split("/")[-2]
+                       video_data['snippet']['thumbnails'].get(key, '').get("url", '').split("/")[-2]
             })
         except:
             pass


### PR DESCRIPTION
[Bugfix/4][Mostrar todos os vídeos de um curso] Utilizando o método get para melhorar a confiabilidade

Utilizando o método .get para o elemento do dicionário.
Caso a chave 'default' não exista será retornada a string vazia

Além disso, o método `get_video_data_snippet` foi removido para que a responsabilidade dessa função permaneça concentrada no método `list_videos`